### PR TITLE
add cell object and related classes

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -4,13 +4,14 @@ import dbms.table.Column;
 import dbms.table.Table;
 import dbms.utilities.CsvRaf;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class Main {
     public static void main(String[] args) throws Exception {
 
         Column.Builder[] columns = {
-            new Column.Builder("Row ID", 4, DataType.INTEGER),
+            new Column.Builder("Row ID", 4, DataType.INTEGER).addExtension(ColumnFlag.AUTO_INCREMENT),
             new Column.Builder("SSN", 9, DataType.STRING).addExtension(ColumnFlag.PRIMARY_KEY),
             new Column.Builder("First Name", 20, DataType.STRING),
             new Column.Builder("Middle Initial", 1, DataType.STRING),
@@ -53,9 +54,13 @@ public class Main {
         // mutate data into the correct format for the table
         csvFile.forEachLineData((lineData, lineIndex) -> {
             String ssnValue = lineData.remove(indexOfSsn).replaceAll("[^\\d.]", "");
-            lineData.addFirst(Integer.valueOf(lineIndex + 1).toString());
-            lineData.add(1, ssnValue);
-            table.addRecord(lineData);
+            lineData.addFirst(ssnValue);
+
+            try {
+                table.addRecord(lineData);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         });
 
         // close csv file

--- a/src/dbms/builders/RecordBuilder.java
+++ b/src/dbms/builders/RecordBuilder.java
@@ -1,0 +1,65 @@
+package dbms.builders;
+
+import dbms.exceptions.InvalidValueCountException;
+import dbms.table.Column;
+import dbms.table.Header;
+import dbms.table.Page;
+import dbms.table.Record;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class RecordBuilder {
+    private final Header header;
+    private final List<String> values;
+
+    // used when a new record data is being inserted into the table
+    public RecordBuilder(Header header, List<String> values) throws InvalidValueCountException {
+        this.header = header;
+        this.values = this.initializeValues(values);
+    }
+
+    // used when record data is being read from disk instead
+    public RecordBuilder(Header header) {
+        this.header = header;
+        this.values = this.initializeEmptyValues();
+    }
+
+    private List<String> initializeValues(List<String> values) throws InvalidValueCountException {
+        // extract column information
+        Column autoIncrementColumn = this.header.getAutoIncrementColumn();
+        int numNonAutoIncrementColumns = this.header.getNonAutoIncrementColumns().size();
+
+        // check for auto increment column and add value if no auto increment value was supplied
+        if ((autoIncrementColumn != null) && (numNonAutoIncrementColumns == values.size())) {
+            values.add(autoIncrementColumn.getIndex(), String.valueOf(autoIncrementColumn.getLargestValue() + 1));
+        }
+
+        // verify that the number of values now matches the number of columns
+        if (this.header.getColumns().size() != values.size()) {
+            throw new InvalidValueCountException(this.header, values);
+        }
+
+        return values;
+    }
+
+    private List<String> initializeEmptyValues() {
+        return IntStream.range(0, header.getColumns().size()).mapToObj(i -> (String) null).toList();
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public List<String> getValues() {
+        return this.values;
+    }
+
+    public String getPrimaryKeyValue() {
+        return this.values.get(this.header.getPrimaryKeyColumn().getIndex());
+    }
+
+    public dbms.table.Record build(Page page) {
+        return new Record(page, this);
+    }
+}

--- a/src/dbms/constants/ColumnFlag.java
+++ b/src/dbms/constants/ColumnFlag.java
@@ -3,4 +3,6 @@ package dbms.constants;
 public enum ColumnFlag {
     PRIMARY_KEY,
     AUTO_INCREMENT,
+    UNIQUE,
+    NOT_NULL,
 }

--- a/src/dbms/exceptions/InvalidValueCountException.java
+++ b/src/dbms/exceptions/InvalidValueCountException.java
@@ -1,0 +1,17 @@
+package dbms.exceptions;
+
+import dbms.table.Header;
+
+import java.util.List;
+
+public class InvalidValueCountException extends Exception {
+    public InvalidValueCountException(Header header, List<String> values) {
+        super(new StringBuilder().append("\n")
+            .append("Reason: The number of values supplied did not match the number of columns.\n")
+            .append("Non auto-increment columns: ").append(header.getNonAutoIncrementColumns()).append("\n")
+            .append("All columns: ").append(header.getColumns()).append("\n")
+            .append("Values: ").append(values).append("\n")
+            .toString()
+        );
+    }
+}

--- a/src/dbms/exceptions/InvalidValueException.java
+++ b/src/dbms/exceptions/InvalidValueException.java
@@ -1,0 +1,14 @@
+package dbms.exceptions;
+
+import dbms.table.Column;
+
+public class InvalidValueException extends Exception {
+    public InvalidValueException(String reason, String value, Column column) {
+        super(new StringBuilder().append("\n")
+            .append("Reason: ").append(reason).append('\n')
+            .append("Value: ").append(value).append('\n')
+            .append("Column: ").append(column).append("\n")
+            .toString()
+        );
+    }
+}

--- a/src/dbms/table/Column.java
+++ b/src/dbms/table/Column.java
@@ -2,24 +2,42 @@ package dbms.table;
 
 import dbms.constants.ColumnFlag;
 import dbms.constants.DataType;
+import dbms.table.cell.ICell;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 public class Column {
 
+    private final Table           table;
     private final Header          header;
     private final String          name;
     private final int             size;
     private final DataType        type;
     private final Set<ColumnFlag> flags;
 
-    public Column(Header header, Builder builder) {
+    public Column(Table table, Header header, Builder builder) {
+        this.table = table;
         this.header = header;
         this.name = builder.name;
         this.size = builder.size;
         this.type = builder.type;
         this.flags = builder.flags;
+    }
+
+    public int getRelativeRecordOffset() {
+        return IntStream.range(0, this.getIndex()).map(i -> this.header.getColumns().get(i).getSize()).sum();
+    }
+
+    public List<ICell> getCells() {
+        int columnIndex = this.getIndex();
+        return this.table.getRecords().stream().map(r -> r.getCells().get(columnIndex)).toList();
+    }
+
+    public int getLargestValue() {
+        return this.getCells().stream().mapToInt(c -> Integer.parseInt(c.getValue())).max().orElse(0);
     }
 
     public int getIndex() {
@@ -63,8 +81,8 @@ public class Column {
             return this;
         }
 
-        public Column build(Header header) {
-            return new Column(header, this);
+        public Column build(Table table, Header header) {
+            return new Column(table, header, this);
         }
     }
 }

--- a/src/dbms/table/Header.java
+++ b/src/dbms/table/Header.java
@@ -10,16 +10,24 @@ public class Header {
 
     private final List<Column> columns;
 
-    protected Header(Column.Builder[] columnBuilders) {
-        this.columns = Arrays.stream(columnBuilders).map(cb -> cb.build(this)).toList();
+    protected Header(Table table, Column.Builder[] columnBuilders) {
+        this.columns = Arrays.stream(columnBuilders).map(cb -> cb.build(table, this)).toList();
     }
 
-    protected List<Column> getColumns() {
+    public List<Column> getColumns() {
         return new ArrayList<>(this.columns);
     }
 
-    protected Column getPrimaryKeyColumn() {
+    public List<Column> getNonAutoIncrementColumns() {
+        return this.getColumns().stream().filter(c -> !c.hasFlag(ColumnFlag.AUTO_INCREMENT)).toList();
+    }
+
+    public Column getPrimaryKeyColumn() {
         return this.columns.stream().filter(c -> c.hasFlag(ColumnFlag.PRIMARY_KEY)).findFirst().orElse(null);
+    }
+
+    public Column getAutoIncrementColumn() {
+        return this.columns.stream().filter(c -> c.hasFlag(ColumnFlag.AUTO_INCREMENT)).findFirst().orElse(null);
     }
 
     protected int getRecordSize() {

--- a/src/dbms/table/Page.java
+++ b/src/dbms/table/Page.java
@@ -1,5 +1,7 @@
 package dbms.table;
 
+import dbms.builders.RecordBuilder;
+import dbms.exceptions.InvalidValueException;
 import dbms.utilities.ExtendedRaf;
 
 import java.io.IOException;
@@ -30,8 +32,10 @@ public class Page {
         return new ArrayList<>(this.records);
     }
 
-    protected void addRecord(List<String> values) {
-        this.records.add(new Record(this, this.header, values));
+    protected void addRecord(RecordBuilder recordBuilder) throws InvalidValueException {
+        Record record = recordBuilder.build(this);
+        this.records.add(record);
+        record.validate();
     }
 
     protected void write(ExtendedRaf raf) throws IOException {
@@ -49,7 +53,7 @@ public class Page {
 
         // sort relative offset of each record by primary key value
         for (Record record : this.records) {
-            keyValueToRelativeOffsetMap.put(record.getPrimaryKeyValue(), record.getPageRelativeOffset());
+            keyValueToRelativeOffsetMap.put(record.getPrimaryKeyCell().getValue(), record.getPageRelativeOffset());
         }
 
         // write relative offsets of each record (sorted by primary key) into header
@@ -75,7 +79,7 @@ public class Page {
 
         // initialize records objects
         for (int i = 0; i < numRecords; i++) {
-            this.records.add(new Record(this, header));
+            this.records.add(new RecordBuilder(header).build(this));
         }
 
         // read data for records from disk

--- a/src/dbms/table/Record.java
+++ b/src/dbms/table/Record.java
@@ -1,35 +1,39 @@
 package dbms.table;
 
-import dbms.constants.DataType;
+import dbms.exceptions.InvalidValueException;
+import dbms.table.cell.CellFactory;
+import dbms.table.cell.ICell;
+import dbms.builders.RecordBuilder;
 import dbms.utilities.ExtendedRaf;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class Record {
 
     private final Page page;
     private final Header header;
-    private final List<String> values;
+    private final List<ICell> cells;
     private boolean markedForDeletion;
 
-    protected Record(Page page, Header header, List<String> values) {
+    public Record(Page page, RecordBuilder builder) {
         this.page = page;
-        this.header = header;
-        this.values = values;
+        this.header = builder.getHeader();
+        this.cells = initializeCells(builder.getValues());
     }
 
-    protected Record(Page page, Header header) {
-        this(page, header, new ArrayList<>(header.getColumns().size()));
+    private List<ICell> initializeCells(List<String> values) {
+        List<Column> columns = this.header.getColumns();
+        return IntStream.range(0, columns.size()).mapToObj(i -> CellFactory.build(this, columns.get(i), values.get(i))).toList();
     }
 
     private int getIndexInPage() {
         return this.page.getRecords().indexOf(this);
     }
 
-    private int getAbsoluteOffset() {
+    public int getAbsoluteOffset() {
         return this.page.getAbsoluteOffset() + this.getPageRelativeOffset();
     }
 
@@ -37,53 +41,32 @@ public class Record {
         return Page.PAGE_SIZE - ((this.getIndexInPage() + 1) * header.getRecordSize());
     }
 
-    protected String getPrimaryKeyValue() {
-        return this.values.get(this.header.getPrimaryKeyColumn().getIndex());
+    protected ICell getPrimaryKeyCell() {
+        return this.cells.get(this.header.getPrimaryKeyColumn().getIndex());
     }
 
-    protected List<String> getValues() {
-        return new ArrayList<>(this.values);
+    protected List<ICell> getCells() {
+        return new ArrayList<>(this.cells);
+    }
+
+    protected void validate() throws InvalidValueException {
+        for (ICell cell : this.cells) { cell.validate(); }
     }
 
     protected void write(ExtendedRaf raf) throws IOException {
         raf.seek(this.getAbsoluteOffset());
-
-        // write record values to disk
-        for (int i = 0; i < this.header.getColumns().size(); i++) {
-            Column column = this.header.getColumns().get(i);
-            String value = this.values.get(i);
-
-            switch (column.getType()) {
-                case DataType.INTEGER -> raf.writeInt(Integer.parseInt(value));
-                case DataType.SHORT -> raf.writeShort(Short.parseShort(value));
-                case DataType.STRING -> raf.write(Arrays.copyOf(value.getBytes(), column.getSize()));
-            }
-        }
-
-        // write deletion marker to disk
+        for (ICell cell: this.cells) { cell.write(raf); }
         raf.writeByte(this.markedForDeletion ? 1 : 0);
     }
 
     protected void read(ExtendedRaf raf) throws IOException {
         raf.seek(this.getAbsoluteOffset());
-
-        // read record values from disk
-        for (int i = 0; i < this.header.getColumns().size(); i++) {
-            Column column = this.header.getColumns().get(i);
-
-            switch (column.getType()) {
-                case DataType.INTEGER -> values.add(i, String.valueOf(raf.readInt()));
-                case DataType.SHORT -> values.add(i, String.valueOf(raf.readShort()));
-                case DataType.STRING -> values.add(i, raf.readString(column.getSize()));
-            }
-        }
-
-        // read deletion marker from disk
+        for (ICell cell: this.cells) { cell.read(raf); }
         this.markedForDeletion = raf.readByte() != 0;
     }
 
     public String toString() {
-        List<String> values = this.getValues();
+        List<String> values = new ArrayList<>(this.cells.stream().map(ICell::getValue).toList());
         values.add(this.markedForDeletion ? "deleted" : "not deleted");
         return values.toString();
     }

--- a/src/dbms/table/cell/AbstractCell.java
+++ b/src/dbms/table/cell/AbstractCell.java
@@ -1,0 +1,64 @@
+package dbms.table.cell;
+
+import dbms.table.Column;
+import dbms.table.Record;
+import dbms.utilities.ExtendedRaf;
+
+import java.io.IOException;
+
+public abstract class AbstractCell implements ICell {
+
+    protected final Record record;
+    protected final Column column;
+    protected String value;
+
+    public AbstractCell(Record record, Column column, String value) {
+        this.record = record;
+        this.column = column;
+        this.value = value;
+    }
+
+    public ICell getDataSource() {
+        return this;
+    }
+
+    private int getAbsoluteOffset() {
+        return this.record.getAbsoluteOffset() + this.column.getRelativeRecordOffset();
+    }
+
+    @Override
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public Column getColumn() {
+        return this.column;
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public void validate() {
+        /* to be implemented in decorators */
+    }
+
+    @Override
+    public void write(ExtendedRaf raf) throws IOException {
+        raf.seek(this.getAbsoluteOffset());
+        this.performWrite(raf);
+    }
+
+    @Override
+    public void read(ExtendedRaf raf) throws IOException {
+        raf.seek(this.getAbsoluteOffset());
+        this.performRead(raf);
+    }
+
+    protected abstract void performWrite(ExtendedRaf raf) throws IOException;
+
+    protected abstract void performRead(ExtendedRaf raf) throws IOException;
+}

--- a/src/dbms/table/cell/CellFactory.java
+++ b/src/dbms/table/cell/CellFactory.java
@@ -1,0 +1,34 @@
+package dbms.table.cell;
+
+import dbms.constants.ColumnFlag;
+import dbms.constants.DataType;
+import dbms.table.Column;
+import dbms.table.Record;
+import dbms.table.cell.decorators.NotNullCellDecorator;
+import dbms.table.cell.decorators.PrimaryKeyCellDecorator;
+import dbms.table.cell.decorators.UniqueCellDecorator;
+import dbms.table.cell.subclasses.IntegerCell;
+import dbms.table.cell.subclasses.ShortCell;
+import dbms.table.cell.subclasses.StringCell;
+
+public class CellFactory {
+    public static ICell build(Record record, Column column, String value) {
+        ICell cell = switch(column.getType()) {
+            case DataType.INTEGER -> new IntegerCell(record, column, value);
+            case DataType.SHORT -> new ShortCell(record, column, value);
+            case DataType.STRING ->  new StringCell(record, column, value);
+        };
+
+        if (column.hasFlag(ColumnFlag.PRIMARY_KEY)) {
+            cell = new PrimaryKeyCellDecorator(cell);
+        }
+        if (column.hasFlag(ColumnFlag.UNIQUE)) {
+            cell = new UniqueCellDecorator(cell);
+        }
+        if (column.hasFlag(ColumnFlag.NOT_NULL)) {
+            cell = new NotNullCellDecorator(cell);
+        }
+
+        return cell;
+    }
+}

--- a/src/dbms/table/cell/ICell.java
+++ b/src/dbms/table/cell/ICell.java
@@ -1,0 +1,36 @@
+package dbms.table.cell;
+
+import dbms.exceptions.InvalidValueException;
+import dbms.table.Column;
+import dbms.utilities.ExtendedRaf;
+
+import java.io.IOException;
+
+public interface ICell {
+
+    public ICell getDataSource();
+
+    public default Column getColumn() {
+        return this.getDataSource().getColumn();
+    }
+
+    public default String getValue() {
+        return this.getDataSource().getValue();
+    }
+
+    public default void setValue(String newValue) throws InvalidValueException {
+        this.getDataSource().setValue(newValue);
+    }
+
+    public default void validate() throws InvalidValueException {
+        this.getDataSource().validate();
+    }
+
+    public default void write(ExtendedRaf raf) throws IOException {
+        this.getDataSource().write(raf);
+    }
+
+    public default void read(ExtendedRaf raf) throws IOException {
+        this.getDataSource().read(raf);
+    }
+}

--- a/src/dbms/table/cell/decorators/AbstractCellDecorator.java
+++ b/src/dbms/table/cell/decorators/AbstractCellDecorator.java
@@ -1,0 +1,16 @@
+package dbms.table.cell.decorators;
+
+import dbms.table.cell.ICell;
+
+public abstract class AbstractCellDecorator implements ICell {
+
+    protected final ICell dataSource;
+
+    public AbstractCellDecorator(ICell dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public ICell getDataSource() {
+        return this.dataSource;
+    }
+}

--- a/src/dbms/table/cell/decorators/NotNullCellDecorator.java
+++ b/src/dbms/table/cell/decorators/NotNullCellDecorator.java
@@ -1,0 +1,27 @@
+package dbms.table.cell.decorators;
+
+import dbms.exceptions.InvalidValueException;
+import dbms.table.cell.ICell;
+
+public class NotNullCellDecorator extends AbstractCellDecorator {
+
+    public NotNullCellDecorator(ICell dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    public void setValue(String newValue) throws InvalidValueException {
+        if (newValue == null) {
+            throw new InvalidValueException("Unable to set value, Value cannot be null.", null, this.getColumn());
+        }
+        getDataSource().setValue(newValue);
+    }
+
+    @Override
+    public void validate() throws InvalidValueException {
+        if (this.getValue() == null) {
+            throw new InvalidValueException("Value cannot be null", this.getValue(), this.getColumn());
+        }
+        getDataSource().validate();
+    }
+}

--- a/src/dbms/table/cell/decorators/PrimaryKeyCellDecorator.java
+++ b/src/dbms/table/cell/decorators/PrimaryKeyCellDecorator.java
@@ -1,0 +1,20 @@
+package dbms.table.cell.decorators;
+
+import dbms.table.cell.ICell;
+
+public class PrimaryKeyCellDecorator extends UniqueCellDecorator {
+
+    public PrimaryKeyCellDecorator(ICell dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    protected String getDuplicateKeyOnSetMessage() {
+        return "Unable to set key value. Key value already exists in column.";
+    }
+
+    @Override
+    protected String getDuplicateKeyOnVerifyMessage() {
+        return "Duplicate key value found in column.";
+    }
+}

--- a/src/dbms/table/cell/decorators/UniqueCellDecorator.java
+++ b/src/dbms/table/cell/decorators/UniqueCellDecorator.java
@@ -1,0 +1,46 @@
+package dbms.table.cell.decorators;
+
+import dbms.exceptions.InvalidValueException;
+import dbms.table.cell.ICell;
+
+import java.util.List;
+
+public class UniqueCellDecorator extends AbstractCellDecorator {
+
+    public UniqueCellDecorator(ICell dataSource) {
+        super(dataSource);
+    }
+
+    protected String getDuplicateKeyOnSetMessage() {
+        return "Unable to set value. Value already exists in column.";
+    }
+
+    protected String getDuplicateKeyOnVerifyMessage() {
+        return "Duplicate value found in column.";
+    }
+
+    @Override
+    public void setValue(String newValue) throws InvalidValueException {
+        validateDuplicateValue(newValue);
+        getDataSource().setValue(newValue);
+    }
+
+    @Override
+    public void validate() throws InvalidValueException {
+        validateDuplicateValue(this.getValue());
+        getDataSource().validate();
+    }
+
+    private void validateDuplicateValue(String value) throws InvalidValueException {
+        if (cellExistsWithSameValue(value)) {
+            throw new InvalidValueException(this.getDuplicateKeyOnVerifyMessage(), this.getValue(), this.getColumn());
+        }
+    }
+
+    private boolean cellExistsWithSameValue(String value) {
+        return this.getColumn().getCells().stream().anyMatch(c -> (
+            c.getDataSource() != this.getDataSource()
+            && c.getValue().equals(value)
+        ));
+    }
+}

--- a/src/dbms/table/cell/subclasses/IntegerCell.java
+++ b/src/dbms/table/cell/subclasses/IntegerCell.java
@@ -1,0 +1,26 @@
+package dbms.table.cell.subclasses;
+
+import dbms.table.Column;
+import dbms.table.Record;
+import dbms.table.cell.AbstractCell;
+import dbms.utilities.ExtendedRaf;
+
+import java.io.IOException;
+import java.lang.String;
+
+public class IntegerCell extends AbstractCell {
+
+    public IntegerCell(Record record, Column column, String value) {
+        super(record, column, value);
+    }
+
+    @Override
+    protected void performWrite(ExtendedRaf raf) throws IOException {
+        raf.writeInt(Integer.parseInt(this.getValue()));
+    }
+
+    @Override
+    protected void performRead(ExtendedRaf raf) throws IOException {
+        this.value = String.valueOf(raf.readInt());
+    }
+}

--- a/src/dbms/table/cell/subclasses/ShortCell.java
+++ b/src/dbms/table/cell/subclasses/ShortCell.java
@@ -1,0 +1,26 @@
+package dbms.table.cell.subclasses;
+
+import dbms.table.Column;
+import dbms.table.Record;
+import dbms.table.cell.AbstractCell;
+import dbms.utilities.ExtendedRaf;
+
+import java.io.IOException;
+import java.lang.String;
+
+public class ShortCell extends AbstractCell {
+
+    public ShortCell(Record record, Column column, String value) {
+        super(record, column, value);
+    }
+
+    @Override
+    protected void performWrite(ExtendedRaf raf) throws IOException {
+        raf.writeShort(java.lang.Short.parseShort(value));
+    }
+
+    @Override
+    protected void performRead(ExtendedRaf raf) throws IOException {
+        this.value = String.valueOf(raf.readShort());
+    }
+}

--- a/src/dbms/table/cell/subclasses/StringCell.java
+++ b/src/dbms/table/cell/subclasses/StringCell.java
@@ -1,0 +1,26 @@
+package dbms.table.cell.subclasses;
+
+import dbms.table.Column;
+import dbms.table.Record;
+import dbms.table.cell.AbstractCell;
+import dbms.utilities.ExtendedRaf;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class StringCell extends AbstractCell {
+
+    public StringCell(Record record, Column column, String value) {
+        super(record, column, value);
+    }
+
+    @Override
+    protected void performWrite(ExtendedRaf raf) throws IOException {
+        raf.write(Arrays.copyOf(value.getBytes(), column.getSize()));
+    }
+
+    @Override
+    protected void performRead(ExtendedRaf raf) throws IOException {
+        this.value = raf.readString(column.getSize());
+    }
+}


### PR DESCRIPTION
## Description

This change abstracts logic related to cells into its own class and also adds additional cell-related classes to handle the different functionalities a cell should have.

## Changes and Features
 
- cells have different subclass types based on the datatype
- cell decorators are available to handle PRIMARY_KEY, UNIQUE, and NOT_NULL functionality
- records can now be inserted without having to specify a field value for the AUTO_INCREMENT column